### PR TITLE
Add anywidget to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# Needed to install onto JupyterLab so that lonboard can connect with it
+anywidget
+
 # Core modules (mandatory)
 jupyterlite-core==0.4.0
 jupyterlab~=4.2.4


### PR DESCRIPTION
Needed for lonboard support. This can't only be installed from user code; it has to be installed both on the "server" (the JupyterLab instance) and from user code.

See https://github.com/jtpio/anywidget-lite/blob/c87dafa76db1a9c49ae0755cbb9c2c8831becaf6/requirements.txt#L1 for reference