### PR TITLE
bump jupyterlite to 0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
     "ipywidgets>=8.1.5",
     "jupyterlab-geojson>=3.4.0",
     "jupyterlab-night>=0.4.6",
-    "jupyterlab>=4.2.5",
-    "jupyterlite-core>=0.8.0b1",
-    "jupyterlite-pyodide-kernel>=0.8.0b0",
-    "notebook>=7.2.2",
+    "jupyterlab>=4.6.0",
+    "jupyterlite-core>=0.8.0",
+    "jupyterlite-pyodide-kernel>=0.8.0",
+    "notebook>=7.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -673,6 +673,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
 name = "jupyter-client"
 version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -787,26 +800,26 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.8"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "packaging" },
-    { name = "setuptools" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/74/089613e6099e851a6130816f2df592c839d8565f8746a701edada05a33e4/jupyterlab-4.5.8.tar.gz", hash = "sha256:af54d7242cc689a1e6c3ad213cc9b6d9781787d9ec67c52ec9a8f4707088cadd", size = 23994076, upload-time = "2026-06-04T12:32:12.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/d1/56a400100559cbf154a23cd29989261941ae5c9f743898fc10e8a5508b7c/jupyterlab-4.5.8-py3-none-any.whl", hash = "sha256:7d514c856d0d607601ec7692374da4f26e2aaf3b6e7cd363136b422a50588d6c", size = 12449443, upload-time = "2026-06-04T12:32:08.442Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
 ]
 
 [[package]]
@@ -884,39 +897,39 @@ requires-dist = [
     { name = "anywidget", specifier = ">=0.9.13" },
     { name = "ipyleaflet", specifier = ">=0.19.2" },
     { name = "ipywidgets", specifier = ">=8.1.5" },
-    { name = "jupyterlab", specifier = ">=4.2.5" },
+    { name = "jupyterlab", specifier = ">=4.6.0" },
     { name = "jupyterlab-geojson", specifier = ">=3.4.0" },
     { name = "jupyterlab-night", specifier = ">=0.4.6" },
-    { name = "jupyterlite-core", specifier = ">=0.8.0b1" },
-    { name = "jupyterlite-pyodide-kernel", specifier = ">=0.8.0b0" },
-    { name = "notebook", specifier = ">=7.2.2" },
+    { name = "jupyterlite-core", specifier = ">=0.8.0" },
+    { name = "jupyterlite-pyodide-kernel", specifier = ">=0.8.0" },
+    { name = "notebook", specifier = ">=7.6.0" },
 ]
 
 [[package]]
 name = "jupyterlite-core"
-version = "0.8.0b1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "doit" },
     { name = "jupyter-core" },
     { name = "pycparser", marker = "platform_python_implementation == 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/78/d3729e8da8318083c24ebc65c95eff8a20478400c9943fde9872d4bd50f1/jupyterlite_core-0.8.0b1.tar.gz", hash = "sha256:eb2be5b66d964396c2a28d273b7fc0902cf587de435142f6a23df2367382b379", size = 15786468, upload-time = "2026-06-02T12:55:55.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/d615b769843dbedcde89f61e59e588d440937308ac9483225078c80438f1/jupyterlite_core-0.8.0.tar.gz", hash = "sha256:051dbb45d401336400a894d9eb8021968bf52645b23ce31a0dfc2914ebcb2faa", size = 15869315, upload-time = "2026-06-23T14:07:15.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/cf/9dc2ce8d51a746cd133f47848e2819b28aa912636b0365328fa8763549f8/jupyterlite_core-0.8.0b1-py3-none-any.whl", hash = "sha256:0a20d0d74f533f6648a3a9f527ff36faefe366d09187dcfdc3d88615c93726d9", size = 15797980, upload-time = "2026-06-02T12:55:53.133Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/75c6d53cfb26136b099ddfea281bc5bc345084faf2968dea2baca820cae7/jupyterlite_core-0.8.0-py3-none-any.whl", hash = "sha256:81234b918bf93c15228b31edc87dac07c92b26bb13148826ced9144407b06daa", size = 15880902, upload-time = "2026-06-23T14:07:11.776Z" },
 ]
 
 [[package]]
 name = "jupyterlite-pyodide-kernel"
-version = "0.8.0b0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyterlite-core" },
     { name = "pkginfo" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/df/db2e2940b4f43bddc30e86bba540fd4dafb261c096dea3f277261636e4db/jupyterlite_pyodide_kernel-0.8.0b0.tar.gz", hash = "sha256:339d386ee420007d5dbababa2281c6febfed8acf36b8ba75b5f83d5bb0fa6fbf", size = 657033, upload-time = "2026-05-25T16:59:39.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5e/6afe0b57405d7624f7916f59d39f6e9c555c176f669a448ce45f1870c85f/jupyterlite_pyodide_kernel-0.8.0.tar.gz", hash = "sha256:515c3036fb985a46876f340922d28e3ecb74e547fa8b8c4f2b36c4f07420e50c", size = 311458, upload-time = "2026-06-24T12:42:50.266Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/9d/b21fa9866e8b68439bc63844ed84b79375a783db4d925b0557e4b559a23c/jupyterlite_pyodide_kernel-0.8.0b0-py3-none-any.whl", hash = "sha256:5c72e432287652dde7ba3cc5091f130b3c6534875482de4680787d1c3dba721f", size = 675770, upload-time = "2026-05-25T16:59:36.701Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/4815b68792bc31685e9219bc0023ee50b4676f4638f2327523605aadaa86/jupyterlite_pyodide_kernel-0.8.0-py3-none-any.whl", hash = "sha256:e7e2785480a51795f14e27946625e6bc8016ae48c8308115c18331a65ded0c8f", size = 325246, upload-time = "2026-06-24T12:42:48.308Z" },
 ]
 
 [[package]]
@@ -1089,18 +1102,19 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.7"
+version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/c4/f71f8716f2903e9e817a47f534b9fd84831e155e2acb32c26691c8e06243/notebook-7.5.7.tar.gz", hash = "sha256:d6d59288a25303b25e1dcb71e9b017ec3a785f7d92f38b9bc288ca1970d5b0a8", size = 14171612, upload-time = "2026-06-04T18:33:45.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/4d/b3347f7073a377273531efe4ffc738fc910e93718fd2838c7ebf6736c6af/notebook-7.5.7-py3-none-any.whl", hash = "sha256:1f95f79d117e47d20b5555b5c85a397d2cfecf136978aaab767cf0314b09165b", size = 14583767, upload-time = "2026-06-04T18:33:40.987Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
 ]
 
 [[package]]
@@ -1655,15 +1669,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This also updates Python to 3.14.

See https://github.com/jupyterlite/jupyterlite/releases/tag/v0.8.0 and https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.8.0

<img width="1195" height="810" alt="image" src="https://github.com/user-attachments/assets/6340fb10-9e68-4de0-ba14-d769ea5fc1a2" />


cc @batpad 